### PR TITLE
changed numbering format for headings to not show a trailing dot

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -107,7 +107,7 @@
   show heading: set text(weight: "semibold", font: heading-font)
 
   //heading numbering
-  set heading(numbering: "1.")
+  set heading(numbering: "1.1.1.1")
  
   // set link style for links that are not acronyms
   show link: it => if (


### PR DESCRIPTION
## Description

As of now content headings have a trailing dot. For example:

```
1. Introduction
1.1. Concepts
1.2. Ideas
2. Chapter
2.1. Basics
```

Most papers (and example works for DHBW) do not use this pattern but instead have a numbering scheme without the trailing dot.
Additionally I think it makes the heading look ugly and overloaded having the extra dot in there. This is how I would expect headings to look:

```
1 Introduction
1.1 Concepts
1.2 Ideas
2 Chapter
2.1 Basics
```

## Changes

- Changed the numbering format of heading to `1.1.1.1`

This change will not append an extra dot at the end of headings. This method works for heading with a depth <= 4.
In order to include headings with a depth > 4 the format requires changes. Since headings with level 4 are already uncommon in papers having support for level 5 headings seems unnecessary from my point of view.