### PR TITLE
Fix declaration of authorhsip when at-university is true

### DIFF
--- a/declaration-of-authorship.typ
+++ b/declaration-of-authorship.typ
@@ -11,8 +11,6 @@
   city,
   date-format,
 ) = {
-  let authors-by-city = authors.map(author => author.company.city).dedup()
-
   v(2em)
   text(size: 20pt, weight: "bold", DECLARATION_OF_AUTHORSHIP_TITLE.at(language))
   v(1em)
@@ -45,6 +43,7 @@
   if (at-university) {
     text(city + [, ] + end-date.display(date-format))
   } else {
+    let authors-by-city = authors.map(author => author.company.city).dedup()
     text(authors-by-city.join(", ", last: AND.at(language)) + [ ] + end-date.display(date-format))
   }
 


### PR DESCRIPTION
When at-university is set to true, the authors must not  have a company attribute.

However, the `declaration-of-authorship.typ` expected a author.company for sorting the authors, even though this sorting would not be used when `at-university` was set to true.
